### PR TITLE
Use the current directory as default path for yamllint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,15 @@ This action executes `yamllint` (https://github.com/adrienverge/yamllint) agains
 
 ## Usage
 
-### Required parameters
-
-- `file_or_dir` - Enter file/folder (space speparated), wildcards accepted. Examples:
-    - `file1.yaml`
-    - `file1.yaml file2.yaml`
-    - `.` - run against all yaml files in a directory recursively
-    - `kustomize/**/*.yaml mychart/*values.yaml`
-
 ### Optional parameters
 
 - `config_file` - Path to custom configuration
 - `config_data` - Custom configuration (as YAML source)
+- `file_or_dir` - Enter file/folder (space separated), wildcards accepted. Examples:
+    - `.` - run against all yaml files in a directory recursively (default)
+    - `file1.yaml`
+    - `file1.yaml file2.yaml`
+    - `kustomize/**/*.yaml mychart/*values.yaml`
 - `format` - Format for parsing output [parsable,standard,colored,auto]
 - `strict` - Return non-zero exit code on warnings as well as errors [true,false]
 
@@ -34,4 +31,18 @@ jobs:
       with:
         file_or_dir: myfolder/*values*.yaml
         config_file: .yamllint.yml
+```
+
+Or just simply check all yaml files in the repository:
+
+```yaml
+name: Yaml Lint
+on: [push]
+jobs:
+  lintAllTheThings:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: yaml-lint
+      uses: ibiqlik/action-yamllint@master
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,10 +4,8 @@ echo "======================"
 echo "= Linting YAML files ="
 echo "======================"
 
-if [ -z "INPUT_FILE_OR_DIR" ]; then
-    echo "file_or_dir not provided, add it in workflow"
-    exit 1
-fi
+# Use the current directory by default
+export INPUT_FILE_OR_DIR=${INPUT_FILE_OR_DIR:-.}
 
 STRICT=""
 if [ "$INPUT_STRICT" == "true" ]; then
@@ -22,4 +20,4 @@ if [ ! -z "$INPUT_CONFIG_DATA" ]; then
     CONFIG_DATA="-d $INPUT_CONFIG_DATA"
 fi
 
-yamllint $CONFIG_FILE $CONFIG_DATA -f $INPUT_FORMAT $STRICT $INPUT_FILE_OR_DIR 
+yamllint $CONFIG_FILE $CONFIG_DATA -f $INPUT_FORMAT $STRICT $INPUT_FILE_OR_DIR


### PR DESCRIPTION
Use the current directory as default path for yamllint.
It's a handy default option which allows yamllint to check all yaml
files in repository by default (which is usually the use case).