### PR TITLE
Use bash in entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3-alpine
 
 RUN pip install yamllint && \
+    apk add bash && \
     rm -rf ~/.cache/pip
 
 ADD entrypoint.sh /entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,23 +1,27 @@
-#!/bin/sh -l
+#!/bin/bash -l
 
 echo "======================"
 echo "= Linting YAML files ="
 echo "======================"
 
+if [[ -n "$INPUT_CONFIG_FILE" ]]; then
+    options+=(-c "$INPUT_CONFIG_FILE")
+fi
+
+if [[ -n "$INPUT_CONFIG_DATA" ]]; then
+    options+=(-d "$INPUT_CONFIG_DATA")
+fi
+
+options+=(-f "$INPUT_FORMAT")
+
+if [[ "$INPUT_STRICT" == "true" ]]; then
+    options+=(-s)
+fi
+
+# Enable globstar so ** globs recursively
+shopt -s globstar
 # Use the current directory by default
-export INPUT_FILE_OR_DIR=${INPUT_FILE_OR_DIR:-.}
+options+=(${INPUT_FILE_OR_DIR:-.})
+shopt -u globstar
 
-STRICT=""
-if [ "$INPUT_STRICT" == "true" ]; then
-    STRICT="-s"
-fi
-
-if [ ! -z "$INPUT_CONFIG_FILE" ]; then
-    CONFIG_FILE="-c $INPUT_CONFIG_FILE"
-fi
-
-if [ ! -z "$INPUT_CONFIG_DATA" ]; then
-    CONFIG_DATA="-d $INPUT_CONFIG_DATA"
-fi
-
-yamllint $CONFIG_FILE $CONFIG_DATA -f $INPUT_FORMAT $STRICT $INPUT_FILE_OR_DIR
+yamllint "${options[@]}"


### PR DESCRIPTION
Added `bash` to `Dockerfile` to write the script in bash. Figured it'd be cleaner than `sh` acrobatics to do recursive globstar and fixing the worksplitting.

Demo of #2 and #3 fixed:

![lol2](https://user-images.githubusercontent.com/646121/74698758-8b41b300-51c4-11ea-9888-1d9604db9985.png)
