### PR TITLE
Autotag releases, use Dockerfile (for now) #5

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,13 @@
+name: Update Semver
+on:
+  push:
+    branches-ignore:
+      - '**'
+    tags:
+      - 'v*.*.*'
+jobs:
+  update-semver:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: haya14busa/action-update-semver@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3-alpine
 
 RUN pip install yamllint && \
-    apk add bash && \
+    apk add --no-cache bash && \
     rm -rf ~/.cache/pip
 
 ADD entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This action executes `yamllint` (https://github.com/adrienverge/yamllint) agains
     - `file1.yaml`
     - `file1.yaml file2.yaml`
     - `kustomize/**/*.yaml mychart/*values.yaml`
-- `format` - Format for parsing output [parsable,standard,colored,auto]
+- `format` - Format for parsing output [parsable,standard,colored,auto] (default: colored)
 - `strict` - Return non-zero exit code on warnings as well as errors [true,false]
 
 ### Example usage in workflow
@@ -27,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: yaml-lint
-      uses: ibiqlik/action-yamllint@master
+      uses: ibiqlik/action-yamllint@v1
       with:
         file_or_dir: myfolder/*values*.yaml
         config_file: .yamllint.yml
@@ -42,7 +42,7 @@ jobs:
   lintAllTheThings:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - name: yaml-lint
       uses: ibiqlik/action-yamllint@master
 ```

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
   format:
     description: 'Format for parsing output [parsable,standard,colored,auto]'
     required: false
-    default: "auto"
+    default: "colored"
   strict:
     description: 'Return non-zero exit code on warnings as well as errors'
     required: false
@@ -23,7 +23,7 @@ inputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ilirbekteshi/action-yamllint'
+  image: 'Dockerfile'
   args:
     - ${{ inputs.file_or_dir }}
     - ${{ inputs.config_file }}


### PR DESCRIPTION
Add wf to autotag minor and patch releases
By default use Dockerfile rather than docker image,
obviously is slower by ~15 sec which consumes precious
runner minutes but harder to automate releases, tagging
and updating image reference in action.yaml
thou not impossible. Next time.