### PR TITLE
Change default output format to parsable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Simple as:
   - `file1.yaml`
   - `file1.yaml file2.yaml`
   - `kustomize/**/*.yaml mychart/*values.yaml`
-- `format` - Format for parsing output [parsable,standard,colored,github,auto] (default: github)
+- `format` - Format for parsing output [parsable,standard,colored,github,auto] (default: parsable)
 - `strict` - Return non-zero exit code on warnings as well as errors [true,false] (default: false)
 
 **Note:** If `.yamllint` configuration file exists in your root folder, yamllint will automatically use it.

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
   format:
     description: 'Format for parsing output [parsable,standard,colored,github,auto]'
     required: false
-    default: "github"
+    default: "parsable"
   strict:
     description: 'Return non-zero exit code on warnings as well as errors'
     required: false


### PR DESCRIPTION
`github` format is barely usable in the logs where it only shows that errors/warnings occurred but not which file:line.