### PR TITLE
Use GITHUB_ACTION_PATH env

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ runs:
     - id: yamllint
       run: |
         # export LOGFILE=$(mktemp yamllint-XXXXXX)
-        ${{ github.action_path }}/entrypoint.sh
+        $GITHUB_ACTION_PATH/entrypoint.sh
       shell: bash
       env:
         INPUT_FILE_OR_DIR: ${{ inputs.file_or_dir }}


### PR DESCRIPTION
Use `GITHUB_ACTION_PATH` environment variable instead of `${{ github.action_path }}` in order to allow execution inside a docker container.

As metioned here:
https://github.com/actions/runner/issues/716#issuecomment-795238933